### PR TITLE
Updated schedule to match 2023-24 bell schedules

### DIFF
--- a/data/mvhs/schedule.yml
+++ b/data/mvhs/schedule.yml
@@ -10,48 +10,55 @@ defaults:
     - weekend
 
 calendar:
-  - 6/9/2022-8/9/2022 weekend "Summer Vacation"
-  - 8/10/2022 schedule-a
-  - 8/15/2022 schedule-g
-  - 9/3/2022-9/5/2022 weekend "Three Day Weekend"
-  - 9/20/2022 schedule-d
-  - 9/21/2022 schedule-e
-  - 10/10/2022 schedule-b
-  - 10/11/2022 schedule-c
-  - 10/12/2022 sat-oct-2022
-  - 10/13/2022-10/16/2022 weekend "End of Quarter/HOCO Break"
-  - 10/17/2022 schedule-g
-  - 10/20/2022 schedule-a
-  - 10/21/2022 schedule-f
-  - 11/7/2022 schedule-b
-  - 11/8/2022 schedule-c
-  - 11/9/2022 schedule-b
-  - 11/10/2022 schedule-c
-  - 11/11/2022 weekend "Veteran's Day"
-  - 11/19/2022-11/27/22 weekend "Thanksgiving Break"
-  - 12/19/2022 finals-dec-2022-mon
-  - 12/20/2022 finals-dec-2022-tues
-  - 12/21/2022 finals-dec-2022-wed
-  - 12/22/2022 finals-dec-2022-thurs
-  - 12/23/22-1/9/23 weekend "Holiday Break"
-  - 1/16/23 weekend "MLK Jr. Day"
-  - 1/30/23 schedule-g
-  - 1/31/23 schedule-h
-  - 2/1/23 schedule-i
-  - 2/18/23-2/26/23 weekend "Winter Break"
-  - 3/18/23-3/20/23 weekend "Three Day Weekend"
-  - 4/8/23-4/16/23 weekend "Spring Break"
-  - 5/22/23 schedule-g
-  - 5/27/23-5/29/23 weekend "Three Day Weekend"
-  - 4/18/2023 sbac-2023-tues
-  - 4/19/2023 sbac-2023-wed
-  - 4/20/2023 sbac-2023-thurs
-  - 4/21/2023 sbac-2023-fri
-  - 5/22/2023 schedule-g
-  - 5/27/2023-5/29/2023 weekend "Three Day Weekend" 
-  - 6/5/2022 finals-june-2023-mon
-  - 6/6/2022 finals-june-2023-tues
-  - 6/7/2022 finals-june-2023-wed
-  - 6/8/2022 finals-june-2023-thurs
-  # Note: 8/9/23 is only used as a placeholder as the start of the 2023-24 school year has not yet been announced
-  - 6/9/23-8/9/23 weekend "Summer Vacation"
+  - 6/8/2023-8/8/2022 weekend "Summer Vacation"
+  - 8/9/2023 schedule-a
+  - 8/10/2023 schedule-a
+  - 8/11/2023 schedule-a
+  - 8/14/2023 schedule-g2
+  - 9/2/2023-9/4/2023 weekend "Labor Day Weekend"
+  - 9/26/2023 schedule-h
+  - 9/27/2023 schedule-i
+  - 10/2/2023 schedule-g3
+  - 10/5/2023 schedule-d
+  - 10/6/2023 schedule-e
+  - 10/9/2023 schedule-b
+  - 10/10/2023 schedule-c
+  - 10/11/2023 sat-oct-2023
+  - 10/12/2023-10/15/2023 weekend "End of Quarter Break"
+  - 11/6/2023 schedule-b
+  - 11/7/2023 schedule-c
+  - 11/8/2023 schedule-b
+  - 11/9/2023 schedule-c
+  - 11/10/2023-11/12/2023 weekend "Veteran's Day Weekend"
+  - 11/18/2023-11/26/2023 weekend "Thanksgiving Break"
+  - 12/19/2023 finals-day-1
+  - 12/20/2023 finals-day-2
+  - 12/21/2023 finals-day-3
+  - 12/22/2023-1/9/23 weekend "Holiday Break"
+  - 1/10/2024 schedule-a
+  - 1/11/2024 schedule-a
+  - 1/12/2024 schedule-a
+  - 1/13/2024-1/15/2024 weekend "MLK Long Weekend"
+  - 1/22/2024 schedule-g4
+  - 2/5/2024 schedule-g2
+  - 2/13/2024 schedule-d
+  - 2/14/2024 schedule-e
+  - 2/17/2024-2/25/2024 weekend "Winter Break"
+  - 3/18/2024 schedule-c
+  - 3/19/2024 schedule-h
+  - 3/20/2024 schedule-i
+  - 3/22/2024 schedule-g3
+  - 3/23/2024-3/25/2024 weekend "End of Quarter Break"
+  - 3/26/2024 sbac-2024-tues
+  - 3/27/2024 sbac-2024-wed
+  - 3/28/2024 sbac-2024-thurs
+  - 3/29/2024 sbac-2024-fri
+  - 4/6/2024-4/14/2024 weekend "Spring Break"
+  - 4/30/2024 schedule-d
+  - 5/1/2024 schedule-e
+  - 5/20/2024 schedule-g4
+  - 5/25/2024-5/27/2024 weekend "Memorial Day Weekend"
+  - 6/4/2024 finals-day-1
+  - 6/5/2024 finals-day-2
+  - 6/6/2024 finals-day-3
+  - 6/7/2024-8/6/2024 weekend "Summer Vacation" # 8/6 Predicted day before 2024-2025 FDoS

--- a/data/mvhs/schedule.yml
+++ b/data/mvhs/schedule.yml
@@ -10,7 +10,7 @@ defaults:
     - weekend
 
 calendar:
-  - 6/8/2023-8/8/2022 weekend "Summer Vacation"
+  - 6/8/2023-8/8/2023 weekend "Summer Vacation"
   - 8/9/2023 schedule-a
   - 8/10/2023 schedule-a
   - 8/11/2023 schedule-a
@@ -34,7 +34,7 @@ calendar:
   - 12/19/2023 finals-day-1
   - 12/20/2023 finals-day-2
   - 12/21/2023 finals-day-3
-  - 12/22/2023-1/9/23 weekend "Holiday Break"
+  - 12/22/2023-1/9/24 weekend "Holiday Break"
   - 1/10/2024 schedule-a
   - 1/11/2024 schedule-a
   - 1/12/2024 schedule-a

--- a/data/mvhs/schedule.yml
+++ b/data/mvhs/schedule.yml
@@ -34,7 +34,7 @@ calendar:
   - 12/19/2023 finals-day-1
   - 12/20/2023 finals-day-2
   - 12/21/2023 finals-day-3
-  - 12/22/2023-1/9/24 weekend "Holiday Break"
+  - 12/22/2023-1/9/2024 weekend "Holiday Break"
   - 1/10/2024 schedule-a
   - 1/11/2024 schedule-a
   - 1/12/2024 schedule-a

--- a/data/mvhs/school.yml
+++ b/data/mvhs/school.yml
@@ -12,9 +12,12 @@ periods:
 # by deafult: Free, Brunch, Break, Lunch, and Passing are non-periods
 non-periods:
   - Tutorial
-  - Office Hours
   - Period 2A
   - Period 2B
+  - Period 3A
+  - Period 3B
+  - Period 4A
+  - Period 4B  
   - Junior ELA Testing
   - Junior Math Testing
   - Junior Math and Senior Science Testing
@@ -27,175 +30,201 @@ weekend:
 schedule-a:
   name: Schedule A
   schedule:
-    - 8:40 Period 1
-    - 9:25 Free
-    - 9:32 Period 2
-    - 10:22 Brunch
-    - 10:32 Free
-    - 10:39 Period 3
-    - 11:24 Free
-    - 11:31 Period 4
-    - 12:16 Lunch
-    - 13:01 Free
-    - 13:08 Period 5
-    - 13:53 Free
-    - 14:00 Period 6
-    - 14:45 Free
-    - 14:52 Period 7
-    - 15:37 Free
+    - 8:30 Period 1
+    - 9:20 Free
+    - 9:27 Period 2
+    - 10:17 Brunch
+    - 10:25 Free
+    - 10:32 Period 3
+    - 11:22 Free
+    - 11:29 Period 4
+    - 12:19 Lunch
+    - 12:54 Free
+    - 13:01 Period 5
+    - 13:51 Free
+    - 13:58 Period 6
+    - 14:48 Free
+    - 14:55 Period 7
+    - 15:45 Free
 
 schedule-b:
   name: Schedule B
   schedule:
-    - 8:40 Period 1
-    - 10:10 Brunch
-    - 10:20 Free
-    - 10:27 Period 3
-    - 11:52 Lunch
-    - 12:37 Free
-    - 12:44 Period 5
-    - 14:09 Free
-    - 14:16 Period 7
-    - 15:41 Free
+    - 8:30 Period 1
+    - 10:00 Brunch
+    - 10:08 Free
+    - 10:15 Period 3
+    - 11:45 Lunch
+    - 12:25 Free
+    - 12:32 Period 5
+    - 14:02 Free
+    - 14:09 Period 7
+    - 15:39 Free
 
 schedule-c:
   name: Schedule C
   schedule:
-    - 8:40 Period 2
-    - 10:10 Tutorial
+    - 8:30 Period 2
+    - 10:00 Free
+    - 10:07 Tutorial
     - 11:00 Brunch
-    - 11:10 Free
-    - 11:17 Period 4
-    - 12:42 Lunch
-    - 13:27 Free
-    - 13:34 Period 6
-    - 14:59 Free
+    - 11:08 Free
+    - 11:15 Period 4
+    - 12:45 Lunch
+    - 13:25 Free
+    - 13:32 Period 6
+    - 15:02 Free
 
 schedule-d:
-  name: Schedule D (Late Start)
+  name: Schedule D (Early Release)
   schedule:
-    - 11:30 Period 1
-    - 12:15 Lunch
-    - 13:00 Free
-    - 13:07 Period 3
-    - 13:52 Free
-    - 13:59 Period 5
-    - 14:44 Free
-    - 14:51 Period 7
-    - 15:36 Free
+    - 8:30 Period 1
+    - 9:30 Free
+    - 9:37 Period 3
+    - 10:37 Brunch
+    - 10:45 Free
+    - 10:52 Period 5
+    - 11:52 Free
+    - 11:59 Period 7
+    - 12:59 Free # <- Technically Lunch 
 
 schedule-e:
-  name: Schedule E (Late Start)
+  name: Schedule E (Early Release)
   schedule:
-    - 11:30 Period 2
-    - 12:15 Lunch
-    - 13:00 Free
-    - 13:07 Period 4
-    - 13:52 Free
-    - 13:59 Period 6
-    - 14:44 Free
+    - 8:30 Period 2
+    - 9:30 Free
+    - 9:37 Tutorial
+    - 10:20 Brunch
+    - 10:28 Free
+    - 10:35 Period 4
+    - 11:35 Free
+    - 11:42 Period 6
+    - 12:42 Free # <- Technically Lunch
 
-schedule-f:
-  name: Schedule F (Minimum Day)
+schedule-g2:
+  name: Schedule G (Rally 2nd)
   schedule:
-    - 8:40 Period 1
-    - 9:08 Free
-    - 9:15 Period 2
-    - 9:43 Free
-    - 9:50 Period 3
-    - 10:18 Free
-    - 10:25 Period 4
+    - 8:30 Period 1
+    - 9:13 Free
+    - 9:20 Period 2A
+    - 10:03 Free
+    - 10:10 Period 2B
     - 10:53 Brunch
-    - 11:03 Free
-    - 11:10 Period 5
-    - 11:38 Free
-    - 11:45 Period 6
-    - 12:13 Free
-    - 12:20 Period 7
-    - 12:48 Free
-
-schedule-g:
-  name: Schedule G (Rally)
-  schedule:
-    - 8:40 Period 1
-    - 9:20 Free
-    - 9:27 Period 2A
-    - 10:07 Free
-    - 10:14 Period 2B
-    - 10:54 Brunch
-    - 11:04 Free
-    - 11:11 Period 3
+    - 11:01 Free
+    - 11:08 Period 3
     - 11:51 Free
     - 11:58 Period 4
-    - 12:38 Lunch
-    - 13:18 Free
+    - 12:41 Lunch
+    - 13:16 Free
     - 13:23 Period 5
-    - 14:03 Free
-    - 14:11 Period 6
-    - 14:51 Free
-    - 14:58 Period 7
-    - 15:38 Free
+    - 14:06 Free
+    - 14:13 Period 6
+    - 14:56 Free
+    - 15:03 Period 7
+    - 15:46 Free
+
+schedule-g3:
+  name: Schedule G (Rally 3rd)
+  schedule:
+    - 8:30 Period 1
+    - 9:13 Free
+    - 9:20 Period 2
+    - 10:03 Brunch
+    - 10:11 Free
+    - 10:18 Period 3A
+    - 11:01 Free
+    - 11:08 Period 3B
+    - 11:51 Free
+    - 11:58 Period 4
+    - 12:41 Lunch
+    - 13:16 Free
+    - 13:23 Period 5
+    - 14:06 Free
+    - 14:13 Period 6
+    - 14:56 Free
+    - 15:03 Period 7
+    - 15:46 Free
+
+schedule-g4:
+  name: Schedule G (Rally 4th)
+  schedule:
+    - 8:30 Period 1
+    - 9:13 Free
+    - 9:20 Period 2
+    - 10:03 Brunch
+    - 10:11 Free
+    - 10:18 Period 3
+    - 11:01 Free
+    - 11:08 Period 4A
+    - 11:51 Free
+    - 11:58 Period 4B
+    - 12:41 Lunch
+    - 13:16 Free
+    - 13:23 Period 5
+    - 14:06 Free
+    - 14:13 Period 6
+    - 14:56 Free
+    - 15:03 Period 7
+    - 15:46 Free
 
 schedule-h:
-  name: Schedule H (Minimum Day)
+  name: Schedule H (Late Start)
   schedule:
-    - 8:40 Period 1
-    - 9:25 Free
-    - 9:32 Period 3
-    - 10:22 Brunch
-    - 10:32 Free
-    - 10:39 Period 5
-    - 11:24 Free
-    - 11:31 Period 7
-    - 12:16 Lunch
-    - 13:00 Free
+    - 10:30 Period 1
+    - 11:30 Free
+    - 11:37 Period 3
+    - 12:37 Lunch
+    - 13:12 Free
+    - 13:19 Period 5
+    - 14:19 Free
+    - 14:26 Period 7
+    - 15:26 Free
 
 schedule-i:
-  name: Schedule I (Minimum Day)
+  name: Schedule I (Late Start)
   schedule:
-    - 8:40 Period 2
-    - 9:25 Free
-    - 9:32 Period 4
-    - 10:22 Brunch
-    - 10:32 Free
-    - 10:39 Period 6
-    - 11:24 Lunch
-    - 12:10 Free
+    - 10:30 Period 2
+    - 11:30 Lunch
+    - 12:05 Free
+    - 12:12 Period 4
+    - 13:12 Free
+    - 13:19 Tutorial
+    - 14:02 Free
+    - 14:09 Period 6
+    - 15:09 Free
 
-finals-june-2023-mon:
-  name: Monday Finals
+finals-day-1:
+  name: Finals (Day 1)
   schedule:
-    - 8:40 Period 3
-    - 10:25 Brunch
-    - 10:55 Free
-    - 11:02 Period 5
-    - 12:47 Free
+    - 8:30 Period 1
+    - 10:30 Break
+    - 10:43 Free
+    - 10:50 Period 6
+    - 12:50 Lunch
+    - 13:30 Free
+    - 13:37 Period 7
+    - 15:37 Free
 
-finals-june-2023-tues:
-  name: Tuesday Finals
+finals-day-2:
+  name: Finals (Day 2)
   schedule:
-    - 8:40 Period 2
-    - 10:25 Brunch
-    - 10:55 Free
-    - 11:02 Period 7
-    - 12:47 Free
+    - 8:30 Period 2
+    - 10:30 Break
+    - 10:43 Free
+    - 10:50 Period 5
+    - 12:50 Free
 
-finals-june-2023-wed:
-  name: Wednesday Finals
+finals-day-3:
+  name: Finals (Day 3)
   schedule:
-    - 8:40 Period 1
-    - 10:25 Brunch
-    - 10:55 Free
-    - 11:02 Period 6
-    - 12:47 Free
+    - 8:30 Period 3
+    - 10:30 Break
+    - 10:43 Free
+    - 10:50 Period 4
+    - 12:50 Free
 
-finals-june-2023-thurs:
-  name: Friday Finals
-  schedule:
-    - 8:40 Period 4
-    - 10:25 Free
-
-sbac-2023-tues:
+#Unsure about SBAC and SAT Schedule Yet, Not Updated
+sbac-2024-tues:
   name: Tuesday SBAC Testing
   schedule:
     - 8:40 Junior ELA Testing
@@ -210,7 +239,7 @@ sbac-2023-tues:
     - 14:26 Period 7
     - 15:16 Free
 
-sbac-2023-wed:
+sbac-2024-wed:
   name: Wednesday SBAC Testing
   schedule:
     - 8:40 Junior ELA Testing
@@ -223,7 +252,7 @@ sbac-2023-wed:
     - 13:29 Period 6
     - 14:19 Free
 
-sbac-2023-thurs:
+sbac-2024-thurs:
   name: Thursday SBAC Testing
   schedule:
     - 8:40 Junior Math and Senior Science Testing
@@ -238,7 +267,7 @@ sbac-2023-thurs:
     - 14:26 Period 7
     - 15:16 Free
 
-sbac-2023-fri:
+sbac-2024-fri:
   name: Friday SBAC Testing
   schedule:
     - 8:40 Junior Math Testing
@@ -251,40 +280,7 @@ sbac-2023-fri:
     - 13:29 Period 6
     - 14:19 Free
 
-finals-dec-2022-mon:
-  name: Monday Finals
-  schedule:
-    - 8:40 Period 3
-    - 10:25 Brunch
-    - 10:55 Free
-    - 11:02 Period 5
-    - 12:47 Free
-
-finals-dec-2022-tues:
-  name: Tuesday Finals
-  schedule:
-    - 8:40 Period 2
-    - 10:25 Brunch
-    - 10:55 Free
-    - 11:02 Period 7
-    - 12:47 Free
-
-finals-dec-2022-wed:
-  name: Wednesday Finals
-  schedule:
-    - 8:40 Period 1
-    - 10:25 Brunch
-    - 10:55 Free
-    - 11:02 Period 6
-    - 12:47 Free
-
-finals-dec-2022-thurs:
-  name: Friday Finals
-  schedule:
-    - 8:40 Period 4
-    - 10:25 Free
-
-sat-oct-2022:
+sat-oct-2023:
   name: PSAT/SAT Testing
   schedule:
     - 8:15 PSAT/SAT Testing


### PR DESCRIPTION
Updated schedule to match 2023-24 MVHS schedule

Based on:
https://mvhs.mvla.net/About-Us/About-Us/Bell-Schedule/index.html
https://www.mvla.net/documents/2023-24-Academic-Calendar-Rev-070723.pdf

Notes:
Currently the PSAT/SAT schedules and SBAC schedules aren't out yet, so only the names were changed.