### PR TITLE
Update MVHS Timing

### DIFF
--- a/data/mvhs/schedule.yml
+++ b/data/mvhs/schedule.yml
@@ -14,7 +14,6 @@ calendar:
   - 8/9/2023 schedule-a
   - 8/10/2023 schedule-a
   - 8/11/2023 schedule-a
-  - 8/14/2023 schedule-g2
   - 9/2/2023-9/4/2023 weekend "Labor Day Weekend"
   - 9/26/2023 schedule-h
   - 9/27/2023 schedule-i


### PR DESCRIPTION
The rally on 8/14 was postponed to a later date (undecided right now). Removing the special g2 schedule on 8/14.

In addition, the timing data has not been reflected on the main periods.io website yet. Any quick fixes to this problem?